### PR TITLE
Added array matching for criteria values

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ has the same effect as
 
 ```puppet
   if => [
-    [ 'name', '==', 'root' ]
-    [ 'name', '==', 'admin' ]
-    [ 'name', '==', 'wheel' ]
+    [ 'name', '==', 'root' ],
+    [ 'name', '==', 'admin' ],
+    [ 'name', '==', 'wheel' ],
   ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,32 @@ Multiple criterias can be nested in an array, eg:
   }
 ```
 
+The value of a criteria can also be an array, when an array, purge will repeat the test once for each element of the array, eg:
+
+```puppet
+  if => [ 'name', '==', [ 'admin', 'root', 'nobody' ]]
+```
+
+has the same effect as
+
+```puppet
+  if => [
+    [ 'name', '==', 'root' ]
+    [ 'name', '==', 'admin' ]
+    [ 'name', '==', 'wheel' ]
+  ]
+```
+
+This is fairly useful in puppet, especially puppet 3, where you want to exclude based on array, eg:
+
+```puppet
+   $exclude_users = [ 'root', 'admin', 'wheel' ]
+
+   purge { 'user':
+     unless => [ 'name', '==', $exclude_users ]
+   }
+```
+
 ## Isomorphism
 
 Purge is not an isomorphic resource, that means that although the resource titles must be unique, you can declare seperate resource declarations to manage the same resource type by using the `resource_type` namevar

--- a/lib/puppet/type/purge.rb
+++ b/lib/puppet/type/purge.rb
@@ -141,15 +141,17 @@ Puppet::Type.newtype(:purge) do
   # and returns true if any of the criteria match
   #
   def evaluate_resource(res,condition)
-    condition.select  {  |param, operator, value|
-      case operator
-      when "!=", "=="
-        res[param.to_sym].to_s.send(operator, value)
-      when "=~"
-        res[param.to_sym] =~ Regexp.new(value)
-      when ">=", "<=", ">", "<"
-        res[param.to_sym].to_i.send(operator, value.to_i)
-      end
+    condition.select  {  |param, operator, value_attr|
+      Array(value_attr).select { |value|
+        case operator
+        when "!=", "=="
+          res[param.to_sym].to_s.send(operator, value)
+        when "=~"
+          res[param.to_sym] =~ Regexp.new(value)
+        when ">=", "<=", ">", "<"
+          res[param.to_sym].to_i.send(operator, value.to_i)
+        end
+      }.length > 0
     }.length == 0
   end
 

--- a/spec/unit/type/purge_spec.rb
+++ b/spec/unit/type/purge_spec.rb
@@ -126,6 +126,13 @@ describe purge do
       [ "present1", "present2", "present3", "present4", "present5" ],
       [ "root", "admin" ],
     ],
+
+    ## Test for criteria value as array for multi-matching
+    [
+      [ "name", "==", [ "present2", "present3" ] ],
+      [ "present1", "present4", "present5" ],
+      [ "present2", "present3" ],
+    ]
   ]
 
   test_matrix.each do |data_set|


### PR DESCRIPTION
This adds the option of specifying an array for a criteria value.....

The value of a criteria can also be an array, when an array, purge will repeat the test once for each element of the array, eg:

```puppet
  if => [ 'name', '==', [ 'admin', 'root', 'nobody' ]]
```

has the same effect as

```puppet
  if => [
    [ 'name', '==', 'root' ]
    [ 'name', '==', 'admin' ]
    [ 'name', '==', 'wheel' ]
  ]
```

This is fairly useful in puppet, especially puppet 3, where you want to exclude based on array, eg:

```puppet
   $exclude_users = [ 'root', 'admin', 'wheel' ]

   purge { 'user':
     unless => [ 'name', '==', $exclude_users ]
   }
```