### PR TITLE
Refactor for 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 2.0.0
+# 2.0.0
+
+
 
 * The purge resource now purges directly from the generate method by calling the set method directly on a types properties,  rather than creating resources that spin off outside of the dependency graph.  This addresses [issue #5](https://github.com/crayfishx/puppet-purge/issues/5).  Adding `notify` to a purge resource will now notify the resource *after* the purges have occured.
 
@@ -15,6 +17,19 @@ Debug: Purging resource User[wham2]
 ```
 
 * Added new attributes `manage_property` and `state` to allow overriding of the default "ensure => absent" behaviour for different types of resources.
+
+
+* Better validation of `noop` mode - if `noop => true` is set in the resource, or the agent is running in noop mode you see
+
+```
+Notice: /Stage[main]/Main/Purge[user]/ensure: current_value purgable, should be purged (noop)
+```
+
+Debug mode shows the resources that would have been purged.
+
+```
+Debug: Would have purged resource User[wham2] with ensure => absent  (noop)
+```
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 2.0.0
+
+* The purge resource now purges directly from the generate method by calling the set method directly on a types properties,  rather than creating resources that spin off outside of the dependency graph.  This addresses [issue #5](https://github.com/crayfishx/puppet-purge/issues/5).  Adding `notify` to a purge resource will now notify the resource *after* the purges have occured.
+
+* Due to the above the output is slightly different, rather than seeing each resource purged in Puppet's notices, there is now just one notice...
+
+```
+Notice: /Stage[main]/Main/Purge[user]/ensure: ensure changed 'purgable' to 'purged'
+```
+
+Debug logging however will show the purges...
+
+```
+Debug: Purging resource User[wham2]
+```
+
+* Added new attributes `manage_property` and `state` to allow overriding of the default "ensure => absent" behaviour for different types of resources.
+
 ## 1.1.0
 
 * Added support for array values to criteria https://github.com/crayfishx/puppet-purge/pull/3

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ When run without parameters the purge type takes a resource type as a title.  Th
 
 * Allows fine tuning of which resources get purged
 * Not isomorphic, meaning multiple purge resource declarations can purge the same resource type
+* Purging doesn't always mean destruction - you can use purge to set other attributes, not just `ensure => absent`
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,33 @@ This is fairly useful in puppet, especially puppet 3, where you want to exclude 
    }
 ```
 
+## Advanced parameters
+
+### `manage_property`
+
+By default, purge will try and purge the resource using the `ensure` parameter.  This attribute allows you to override which property gets managed for the resource type.
+
+### `state`
+
+By default, purge will try and set the attribute defined in `manage_property` to `absent`. This behaviour can be overridden here to set the property with a different value.  When used in conjunction with `manage_property` you can define different behaviours rather than all out destruction of resources.  Eg:
+
+```puppet
+  # Don't delete unmnaged mounts, just make sure they are not mounted.
+
+  purge { 'mount':
+    'state' => 'unmounted',
+  }
+```
+
+```puppet
+  # If we find users that are not managed by puppet, then we should set the shell to nologin
+
+  purge { 'user':
+    'manage_property' => 'shell',
+    'state'           => '/bin/nologin',
+  }
+```
+
 ## Isomorphism
 
 Purge is not an isomorphic resource, that means that although the resource titles must be unique, you can declare seperate resource declarations to manage the same resource type by using the `resource_type` namevar

--- a/lib/puppet/type/purge.rb
+++ b/lib/puppet/type/purge.rb
@@ -184,11 +184,11 @@ Puppet::Type.newtype(:purge) do
       # Call the set method of the types property, this should trickle
       # down to the provider and set the desired state of the resource
       #
-      if Puppet.setting[:noop] || self[:noop]
-        Puppet.debug("Would have purged resource #{res.ref}")
+      if Puppet.settings[:noop] || self[:noop]
+        Puppet.debug("Would have purged resource #{res.ref} with #{manage_property} => #{state}  (noop)")
       else
         res.property(manage_property).set(state)
-        Puppet.debug("Purging resource #{res.ref}")
+        Puppet.debug("Purging resource #{res.ref} with #{manage_property} => #{state}")
       end
 
       # Record this in @purged_resources, this gives some visability

--- a/lib/puppet/type/purge.rb
+++ b/lib/puppet/type/purge.rb
@@ -2,30 +2,48 @@ require 'puppet'
 
 Puppet::Type.newtype(:purge) do
 
-  
+  attr_reader :purged_resources
+
   @doc=(<<-EOT)
-  This is a metatype to purge resources from the agent.  When run without 
-  parameters the purge type takes a resource type as a title.  The 
+  This is a metatype to purge resources from the agent.  When run without
+  parameters the purge type takes a resource type as a title.  The
   resource type must be one that has a provider that supports the instances
   method (eg: package, user, yumrepo).  Any instances of the resource found
   on the agent that are *not* in the catalog will be purged.
 
-  You can also add filter conditions to control the behaviour of purge 
+  You can also add filter conditions to control the behaviour of purge
   using the if and unless parameters.
 
   Eg:
   To remove *all* users found on the system that are not present in the
   catalog (caution!):
- 
+
    purge { 'user': }
 
   To remove all users found on the system but not in the catalog, unless
   the user has a UID below 500:
- 
+
    purge { 'user':
     unless => [ 'uid', '<=', '500' ],
    }
   EOT
+
+  ensurable do
+    defaultto(:purged)
+    newvalue(:purgable)
+    newvalue(:purged) do
+      true
+    end
+
+    def retrieve
+      if @resource.purged?
+        :purgable
+      else
+        :purged
+      end
+    end
+  end
+
 
   # By setting @isomorphic to false Puppet will allow duplicate namevars
   # (not duplicate titles).  This allows for multiple purge resource types
@@ -42,13 +60,35 @@ Puppet::Type.newtype(:purge) do
   end
 
 
+  newparam(:manage_property) do
+    desc <<-EOT
+    The manage property parameter defined which property to manage on the resource.
+    The property defined here will be set with the value of `state` and then
+    the `set` method is called on the resources property.
+    `manage_property` defaults to "ensure"
+    EOT
+
+    defaultto :ensure
+  end
+
+  newparam(:state) do
+    desc <<-EOT
+    Define the desired state of the purged resources.  This sets the value of the
+    property defined in `manage_property` before `set` is called on the property.
+    `state` defaults to "absent"
+    EOT
+
+    defaultto :absent
+  end
+
+
   [ :unless, :if ]. each do |param_name|
     newparam(param_name, :array_matching => :all) do
 
       desc(<<-EOT)
       Purge resources #{param_name.to_s} they meet the criteria.
       Criteria is defined as an array of "parameter", "operator", and "value".
-      
+
       Eg:
          #{param_name.to_s} => [ 'name', '==', 'root' ]
 
@@ -57,7 +97,7 @@ Puppet::Type.newtype(:purge) do
 
       Multiple criterias can be nested in an array, eg:
 
-         #{param_name.to_s} => [ 
+         #{param_name.to_s} => [
            [ 'name', '==', 'root' ], [ 'name', '=~', 'admin.*' ]
          ]
       EOT
@@ -67,7 +107,7 @@ Puppet::Type.newtype(:purge) do
       validate do |cond|
         raise ArgumentError, "must be an array" unless cond.is_a?(Array)
       end
-  
+
       munge do |cond|
         if cond[0].is_a?(Array)
           cond
@@ -75,7 +115,7 @@ Puppet::Type.newtype(:purge) do
           [ cond ]
         end
       end
-  
+
       validate do |cond_param|
         case cond_param[0]
         when String
@@ -83,42 +123,74 @@ Puppet::Type.newtype(:purge) do
         when Array
           cond = cond_param
         end
-  
+
         cond.each do |param, operator, value|
           unless ["!=","==","=~",">","<","<=",">="].include?(operator)
             raise ArgumentError, "invalid operator #{operator}"
           end
-  
+
           unless param && operator && value
             raise ArgumentError, "not enough parameters given for filter"
           end
         end
       end
     end
-
-
-
   end
 
-  
+
+  def manage_property
+    self[:manage_property].to_sym
+  end
+
+  def state
+    self[:state]
+  end
 
   def generate
     klass = Puppet::Type.type(self[:name])
+
+    unless klass.validproperty?(manage_property)
+      err "Purge of resource type #{self[:name]} failed, #{manage_property} is not a valid property"
+    end
+
+
     resource_instances = klass.instances
+    metaparams = @parameters.select { |n, p| p.metaparam? }
 
-    purged_resources = []
+    @purged_resources = []
 
-    ## Don't try and perge things that are in the catalog
+    ## Don't try and purge things that are in the catalog
     resource_instances.reject!{ |r| catalog.resource_refs.include? r.ref }
 
     ## Don't purge things that have been filtered with if/unless
     resource_instances = resource_instances.select { |r| purge?(r) }
 
+    ## Don't purge things that are already in sync
+    resource_instances = resource_instances.reject { |r|
+      is = r.property(manage_property).retrieve
+      should = is.is_a?(Symbol) ? state.to_sym : state
+      puts "PRESERVING #{r.name} #{is} == #{should}" if is == should
+      is == should
+    }
+
+
     resource_instances.each do |res|
-      res[:ensure] = :absent
-      purged_resources << res
+      res.property(manage_property).set(state)
+      Puppet.debug("Purging resource #{res.ref}")
+      @purged_resources << res
     end
-    purged_resources
+    @purged_resources
+    []
+  end
+
+  # This method is called from the ensure block after generate() has
+  # identified resources to purge.  If it returns true then it indiciates
+  # that resources have been purged and therefore puts the purge resource
+  # in a changed state so it can be used in refresh event relationships
+  # (notify, subscribe...etc) in Puppet.
+  #
+  def purged?
+    purged_resources.length > 0
   end
 
   # purge will evaluate the conditions given in if/unless

--- a/lib/puppet/type/purge.rb
+++ b/lib/puppet/type/purge.rb
@@ -183,8 +183,13 @@ Puppet::Type.newtype(:purge) do
 
       # Call the set method of the types property, this should trickle
       # down to the provider and set the desired state of the resource
-      res.property(manage_property).set(state)
-      Puppet.debug("Purging resource #{res.ref}")
+      #
+      if Puppet.setting[:noop] || self[:noop]
+        Puppet.debug("Would have purged resource #{res.ref}")
+      else
+        res.property(manage_property).set(state)
+        Puppet.debug("Purging resource #{res.ref}")
+      end
 
       # Record this in @purged_resources, this gives some visability
       # in testing but also is used by ensurable to determine if this

--- a/spec/unit/type/purge_spec.rb
+++ b/spec/unit/type/purge_spec.rb
@@ -64,7 +64,6 @@ describe purge do
 
     it "should do return an array" do
       expect(@output).to be_a(Array)
-      p @output
     end
 
     it "should only contain user resources" do

--- a/spec/unit/type/purge_spec.rb
+++ b/spec/unit/type/purge_spec.rb
@@ -29,9 +29,11 @@ describe purge do
     @catalog_resources = []
 
     system_users.each { |username,uid|
-      res = Puppet::Type.type(:user).new(:name => username)
+      res = Puppet::Type.type(:user).new(:name => username, :ensure => :present)
       res.stubs(:to_resource).returns(res)
+      res.property(:ensure).stubs(:retrieve).returns(:present)
       res.stubs(:to_hash).returns({:name => username, :uid => uid, :ensure => :present })
+      res.property(:ensure).stubs(:set).returns('')
       @system_resources << res 
     }
 
@@ -56,11 +58,13 @@ describe purge do
     before do
       @purge = Puppet::Type.type(:purge).new(:name => 'user')
       @catalog.add_resource(@purge)
-      @output = @purge.generate
+      @purge.generate
+      @output = @purge.purged_resources
     end
 
     it "should do return an array" do
       expect(@output).to be_a(Array)
+      p @output
     end
 
     it "should only contain user resources" do
@@ -72,8 +76,8 @@ describe purge do
 
     it "should purge the present1,2,3,4,5 users" do
       ['1','2','3','4','5'].each do |n|
-        ensure_param=@output.select { |r| r.name == "present#{n}" }[0][:ensure]
-        expect(ensure_param).to eq(:absent)
+        users = @output.map { |r| r.name }
+        expect(users).to include("present#{n}")
       end
     end
 
@@ -152,7 +156,8 @@ describe purge do
         before do
           @purge = Puppet::Type.type(:purge).new(:name => 'user', flag => criteria )
           @catalog.add_resource(@purge)
-          @output = @purge.generate
+          @purge.generate
+          @output = @purge.purged_resources
           @users = @output.map { |r| r.name }
         end
 
@@ -167,8 +172,6 @@ describe purge do
         purge_set.each do |u|
           it "should purge user #{u}" do
             expect(@users).to include(u)
-            res = @output.select { |r| r.name == u }[0]
-            expect(res[:ensure]).to eq(:absent)
           end
         end
       end
@@ -185,7 +188,8 @@ describe purge do
 
       @purge = Puppet::Type.type(:purge).new(opts)
       @catalog.add_resource(@purge)
-      @output = @purge.generate
+      @purge.generate
+      @output = @purge.purged_resources
       @users = @output.map { |r| r.name }
     end
 


### PR DESCRIPTION
## 2.0.0

* The purge resource now purges directly from the generate method by calling the set method directly on a types properties,  rather than creating resources that spin off outside of the dependency graph.  This addresses [issue #5](https://github.com/crayfishx/puppet-purge/issues/5).  Adding `notify` to a purge resource will now notify the resource *after* the purges have occured....

```puppet
purge { 'foo':
  notify => Exec['do something']
}
```

* Due to the above the output is slightly different, rather than seeing each resource purged in Puppet's notices, there is now just one notice...

```
Notice: /Stage[main]/Main/Purge[user]/ensure: ensure changed 'purgable' to 'purged'
```

Debug logging however will show the purges...

```
Debug: Purging resource User[wham2]
```

* Added new attributes `manage_property` and `state` to allow overriding of the default "ensure => absent" behaviour for different types of resources.

## Commit message:

* Generate method calls the `set` method on the types properties directly
* Fixed issue with resources floating out of dependancy graph
* Added `manage_property` attribute
* Added `state` attribute
* Purge resource now signals a changed state, meaning Puppet can set relationships