### PR TITLE
Use `resource.retrieve` for Puppet Resource API compatibility

### DIFF
--- a/lib/puppet/type/purge.rb
+++ b/lib/puppet/type/purge.rb
@@ -172,7 +172,11 @@ Puppet::Type.newtype(:purge) do
 
     ## Don't purge things that are already in sync
     resource_instances = resource_instances.reject { |r|
-      is = r.property(manage_property).retrieve
+      is = begin
+             r.property(manage_property).retrieve
+           rescue NoMethodError
+             r.retrieve[manage_property]
+           end
       should = is.is_a?(Symbol) ? state.to_sym : state
       is == should
     }


### PR DESCRIPTION
`resource.property(name).retrieve` requires a provider that uses
`mk_resource_methods` or equivalent, which is not the case with the
Puppet Resource API.

If `resource.property(name).retrieve` raises `NoMethodError`, fallback to 
`resource.retrieve[]` which is implemented in the Puppet Resource API.

Thanks @DavidS for the suggestion.